### PR TITLE
Provide datasheet cloning script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated Excel clones and caches
+cloned_*.xlsx
+__pycache__/

--- a/README_clone.md
+++ b/README_clone.md
@@ -1,0 +1,19 @@
+# Cloning the Design Datasheet
+
+This repository includes a short Python script `clone_datasheet.py` that reads
+`AE1222II_AircraftDesignDataSheet2025(AutoRecovered).xlsx` and writes a separate
+copy `cloned_AE1222II.xlsx`. The original Excel file is left untouched in
+accordance with the project instructions found in `group.txt`.
+
+The generated clone **is not tracked in Git**. Run the script locally whenever
+you need a fresh copy and avoid committing the resulting `.xlsx` file.
+
+Run the script using:
+
+```bash
+python3 clone_datasheet.py
+```
+
+This will produce a clone of the datasheet in the working directory. If you need
+to edit or complete the datasheet, modify the cloned copy rather than the
+original file.

--- a/clone_datasheet.py
+++ b/clone_datasheet.py
@@ -1,0 +1,26 @@
+import openpyxl
+from pathlib import Path
+
+SOURCE = Path('AE1222II_AircraftDesignDataSheet2025(AutoRecovered).xlsx')
+DEFAULT_TARGET = Path('cloned_AE1222II.xlsx')
+
+def clone_excel(source: Path, target: Path) -> None:
+    """Clone an Excel workbook without modifying the source file."""
+    wb = openpyxl.load_workbook(source)
+    wb.save(target)
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Clone the design datasheet")
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=str(DEFAULT_TARGET),
+        help="Path for the cloned workbook (default: cloned_AE1222II.xlsx)",
+    )
+    args = parser.parse_args()
+
+    target = Path(args.target)
+    clone_excel(SOURCE, target)
+    print(f"Cloned '{SOURCE}' -> '{target}'")


### PR DESCRIPTION
## Summary
- add `.gitignore` to avoid committing generated spreadsheets
- update README with instructions that cloned workbooks aren't tracked
- enhance cloning script with CLI argument for output path
- remove the generated Excel clone from version control

## Testing
- `python3 clone_datasheet.py test_clone.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_684b7ec88e4c833080cc99e49d56a5d5